### PR TITLE
Fix bug in expandComputedStyle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domdiffing",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Dom Diffing finds dom differences between two doms",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/domDiffingEngine.ts
+++ b/src/domDiffingEngine.ts
@@ -31,8 +31,9 @@ const expandComputedStyle = (dom: any, parentCssProps: any) => {
   }
 
   // expandComputedStyle of the childNodes
-  for(let i=0; i<dom[tagName]["childNodes"].length; i++){
-    expandComputedStyle(dom[tagName]["childNodes"], cssProps);
+  const childNodes = dom[tagName]["childNodes"];
+  for (let i = 0; i < childNodes?.length; i++) {
+    expandComputedStyle(childNodes[i], cssProps);
   }
 }
 


### PR DESCRIPTION
On the bright side, exploiting the Cascade for the DOM+CSS snapshots brought the p99 at 8174ms for 520+ tests with 100% reliability, and a huge improvement on the duration of these tests.