### PR TITLE
Discard SVG children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domdiffing",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Dom Diffing finds dom differences between two doms",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/parseDomPlaywright.ts
+++ b/src/parseDomPlaywright.ts
@@ -51,7 +51,7 @@ const parseHTMLAndKeepRelations = (selector: string = "html") => {
         };
     
         let nthChild = 0;
-        if(node.hasChildNodes()){
+        if(node.hasChildNodes() && name != "svg"){
             for(const childNode of node.childNodes){
                 const childTagName = childNode.tagName; 
                 if (childTagName && childTagName !== "SCRIPT" && childTagName !== "STYLE"){


### PR DESCRIPTION
Unless we specifically target SVG documents, SVG children are not relevant for the DOM+CSS snapshot

Here's the impact of this change on the biggest snapshot I have seen:

* 150MB → 19MB before cascade and compression
* 2968kb → 572kb after cascade eg. the amount of data we are then compressing in the browser
* **1382kb → 182kb** after compression eg the amount of data sent to node and stored in blob storage  

That particular snapshot is an extreme case, but overall, for the 320 stories of the largest 1JS package, this change brings the total size of the compressed DOM+CSS snapshots from **50.3MB → 24MB** to transfer from the browser to node, and blob storage.